### PR TITLE
update 2020 to 2021

### DIFF
--- a/2021-03-11-canary-026.md
+++ b/2021-03-11-canary-026.md
@@ -23,7 +23,7 @@ the Qubes Security Pack (qubes-secpack).
 
 View Qubes Canary 026 in the qubes-secpack:
 
-<https://github.com/QubesOS/qubes-secpack/blob/master/canaries/canary-026-2020.txt>
+[https://github.com/QubesOS/qubes-secpack/blob/master/canaries/canary-026-2021.txt](https://github.com/QubesOS/qubes-secpack/blob/master/canaries/canary-026-2021.txt)
 
 Learn about the qubes-secpack, including how to obtain, verify, and
 read it:


### PR DESCRIPTION
fixes a broken link for canary 26-2021