### PR TITLE
Fix htmlproofer errors in recent qubes-doc PRs eleven76 & eleven77...

### DIFF
--- a/2016-09-02-4-0-minimum-requirements-3-2-extended-support.md
+++ b/2016-09-02-4-0-minimum-requirements-3-2-extended-support.md
@@ -104,5 +104,5 @@ the 4.x series.
 [Intel-list]: https://ark.intel.com/Search/FeatureFilter?productType=processors&InstructionSet=64-bit&ExtendedPageTables=true&VTD=true&EM64=true
 [IOMMU-list]: https://en.wikipedia.org/wiki/List_of_IOMMU-supporting_hardware
 [HCL]: /hcl/
-[submitting an HCL report]: /doc/hcl/#generating-and-submitting-new-reports
+[submitting an HCL report]: /doc/how-to-use-the-hcl/#generating-and-submitting-new-reports
 


### PR DESCRIPTION
caused by hcl.md file rename in qubes-doc commit [7d894a59](https://github.com/QubesOS/qubes-doc/commit/7d894a5971f204e6fc594204049a3b1ad21f40ec).