### PR TITLE
Remove references to nonexisting Split SSH GUI

### DIFF
--- a/2023-06-02-qubes-os-4-2-0-rc1-available-for-testing.md
+++ b/2023-06-02-qubes-os-4-2-0-rc1-available-for-testing.md
@@ -23,7 +23,7 @@ We're pleased to announce that the first [release candidate](#what-is-a-release-
 - fwupd integration for firmware updates
 - Optional automatic clipboard clearing
 - Official packages built using Qubes Builder v2
-- Split GPG and Split SSH management in Qubes Global Settings
+- Split GPG management in Qubes Global Settings
 
 Please see the [Qubes OS 4.2.0 release notes](/doc/releases/4.2/release-notes/) for details.
 

--- a/2023-08-28-qubes-os-4-2-0-rc2-available-for-testing.md
+++ b/2023-08-28-qubes-os-4-2-0-rc2-available-for-testing.md
@@ -24,7 +24,7 @@ We're pleased to announce that the second [release candidate](#what-is-a-release
 - fwupd integration for firmware updates
 - Optional automatic clipboard clearing
 - Official packages built using Qubes Builder v2
-- Split GPG and Split SSH management in Qubes Global Settings
+- Split GPG management in Qubes Global Settings
 
 Please see the [Qubes OS 4.2.0 release notes](/doc/releases/4.2/release-notes/) for details.
 


### PR DESCRIPTION
https://github.com/search?q=org%3AQubesOS+qubes.SshAgent&type=code
https://forum.qubes-os.org/t/qubes-os-4-2-where-is-split-ssh-in-gui/22148