### PR TITLE
Fix remaining doc section links

### DIFF
--- a/2025-07-11-qsb-108.md
+++ b/2025-07-11-qsb-108.md
@@ -179,7 +179,7 @@ The purpose of this announcement is to inform the Qubes community that a new Qub
 
 ## What is a Qubes security bulletin (QSB)?
 
-A Qubes security bulletin (QSB) is a security announcement issued by the [Qubes security team](/security/#qubes-security-team). A QSB typically provides a summary and impact analysis of one or more recently-discovered software vulnerabilities, including details about patching to address them. For a list of all QSBs, see [Qubes security bulletins (QSBs)](/security/qsb/).
+A Qubes security bulletin (QSB) is a security announcement issued by the [Qubes security team](https://doc.qubes-os.org/en/latest/project-security/security.html#qubes-security-team). A QSB typically provides a summary and impact analysis of one or more recently-discovered software vulnerabilities, including details about patching to address them. For a list of all QSBs, see [Qubes security bulletins (QSBs)](/security/qsb/).
 
 ## Why should I care about QSBs?
 
@@ -195,7 +195,7 @@ A forged QSB could deceive you into taking actions that adversely affect the sec
 
 ## How do I verify the PGP signatures on a QSB?
 
-The following command-line instructions assume a Linux system with `git` and `gpg` installed. (For Windows and Mac options, see [OpenPGP software](/security/verifying-signatures/#openpgp-software).)
+The following command-line instructions assume a Linux system with `git` and `gpg` installed. (For Windows and Mac options, see [OpenPGP software](https://doc.qubes-os.org/en/latest/project-security/verifying-signatures.html#openpgp-software).)
 
 1. Obtain the Qubes Master Signing Key (QMSK), e.g.:
 
@@ -210,7 +210,7 @@ The following command-line instructions assume a Linux system with `git` and `gp
    gpg:               imported: 1
    ```
 
-   (For more ways to obtain the QMSK, see [How to import and authenticate the Qubes Master Signing Key](/security/verifying-signatures/#how-to-import-and-authenticate-the-qubes-master-signing-key).)
+   (For more ways to obtain the QMSK, see [How to import and authenticate the Qubes Master Signing Key](https://doc.qubes-os.org/en/latest/project-security/verifying-signatures.html#how-to-import-and-authenticate-the-qubes-master-signing-key).)
 
 2. View the fingerprint of the PGP key you just imported. (Note: `gpg>` indicates a prompt inside of the GnuPG program. Type what appears after it when prompted.)
 
@@ -231,7 +231,7 @@ The following command-line instructions assume a Linux system with `git` and `gp
     Primary key fingerprint: 427F 11FD 0FAA 4B08 0123  F01C DDFA 1A3E 3687 9494
    ```
 
-3. **Important:** At this point, you still don't know whether the key you just imported is the genuine QMSK or a forgery. In order for this entire procedure to provide meaningful security benefits, you *must* authenticate the QMSK out-of-band. **Do not skip this step!** The standard method is to obtain the QMSK fingerprint from *multiple independent sources in several different ways* and check to see whether they match the key you just imported. For more information, see [How to import and authenticate the Qubes Master Signing Key](/security/verifying-signatures/#how-to-import-and-authenticate-the-qubes-master-signing-key).
+3. **Important:** At this point, you still don't know whether the key you just imported is the genuine QMSK or a forgery. In order for this entire procedure to provide meaningful security benefits, you *must* authenticate the QMSK out-of-band. **Do not skip this step!** The standard method is to obtain the QMSK fingerprint from *multiple independent sources in several different ways* and check to see whether they match the key you just imported. For more information, see [How to import and authenticate the Qubes Master Signing Key](https://doc.qubes-os.org/en/latest/project-security/verifying-signatures.html#how-to-import-and-authenticate-the-qubes-master-signing-key).
 
    **Tip:** After you have authenticated the QMSK out-of-band to your satisfaction, record the QMSK fingerprint in a safe place (or several) so that you don't have to repeat this step in the future.
 
@@ -280,7 +280,7 @@ The following command-line instructions assume a Linux system with `git` and `gp
    Resolving deltas: 100% (1910/1910), done.
    ```
 
-6. Import the included PGP keys. (See our [PGP key policies](/security/pack/#pgp-key-policies) for important information about these keys.)
+6. Import the included PGP keys. (See our [PGP key policies](https://doc.qubes-os.org/en/latest/project-security/security-pack.html#pgp-key-policies) for important information about these keys.)
 
    ```shell_session
    $ gpg --import qubes-secpack/keys/*/*

--- a/2025-07-23-qubes-documentation-migrating-to-read-the-docs.md
+++ b/2025-07-23-qubes-documentation-migrating-to-read-the-docs.md
@@ -4,7 +4,7 @@ title: "The Qubes documentation is migrating to Read the Docs!"
 categories: announcements
 ---
 
-We're pleased to announce that we're officially migrating to [Read the Docs](https://readthedocs.com/) as our documentation generation and hosting platform. Our documentation source files will continue to reside in the [qubes-doc](https://github.com/QubesOS/qubes-doc) Git repository with [PGP-signed tags and commits](/security/verifying-signatures/#how-to-verify-signatures-on-git-repository-tags-and-commits), and the live documentation published on the web will continue to be located on the official Qubes website, but Read the Docs will handle generating the documentation from our source files and hosting the generated documentation on the backend so that it can be served to Qubes website visitors. Migrating to Read the Docs will enable us to localize the documentation, maintain release-specific documentation, support offline documentation, and more. Today marks the beginning of a 20-day community testing period for the new documentation, which is already live at <https://doc.qubes-os.org/en/latest/>.
+We're pleased to announce that we're officially migrating to [Read the Docs](https://readthedocs.com/) as our documentation generation and hosting platform. Our documentation source files will continue to reside in the [qubes-doc](https://github.com/QubesOS/qubes-doc) Git repository with [PGP-signed tags and commits](https://doc.qubes-os.org/en/latest/project-security/verifying-signatures.html#how-to-verify-signatures-on-git-repository-tags-and-commits), and the live documentation published on the web will continue to be located on the official Qubes website, but Read the Docs will handle generating the documentation from our source files and hosting the generated documentation on the backend so that it can be served to Qubes website visitors. Migrating to Read the Docs will enable us to localize the documentation, maintain release-specific documentation, support offline documentation, and more. Today marks the beginning of a 20-day community testing period for the new documentation, which is already live at <https://doc.qubes-os.org/en/latest/>.
 
 ## What is Read the Docs?
 
@@ -28,7 +28,7 @@ Accordingly, the Qubes documentation source files will continue to reside in the
 
 ## How will this affect the security of the documentation?
 
-The source files for all official Qubes documentation will continue to be stored in the [qubes-doc](https://github.com/QubesOS/qubes-doc) Git repository with [PGP-signed tags and commits](/security/verifying-signatures/#how-to-verify-signatures-on-git-repository-tags-and-commits), just as they are now. In that sense, the security of the documentation won't change at all. The main change is that Read the Docs will replace GitHub as the platform that generates the documentation from the source files and hosts the generated documentation.
+The source files for all official Qubes documentation will continue to be stored in the [qubes-doc](https://github.com/QubesOS/qubes-doc) Git repository with [PGP-signed tags and commits](https://doc.qubes-os.org/en/latest/project-security/verifying-signatures.html#how-to-verify-signatures-on-git-repository-tags-and-commits), just as they are now. In that sense, the security of the documentation won't change at all. The main change is that Read the Docs will replace GitHub as the platform that generates the documentation from the source files and hosts the generated documentation.
 
 ## How will the migration proceed?
 

--- a/2025-08-10-qubes-os-4-3-0-rc1-available-for-testing.md
+++ b/2025-08-10-qubes-os-4-3-0-rc1-available-for-testing.md
@@ -22,7 +22,7 @@ These are just a few highlights from the many changes included in this release. 
 
 ## When is the stable release?
 
-That depends on the number of bugs discovered in this RC and their severity. As explained in our [release schedule](/doc/version-scheme/#release-schedule) documentation, our usual process after issuing a new RC is to collect bug reports, triage the bugs, and fix them. If warranted, we then issue a new RC that includes the fixes and repeat the process. We continue this iterative procedure until we're left with an RC that's good enough to be declared the stable release. No one can predict, at the outset, how many iterations will be required (and hence how many RCs will be needed before a stable release), but we tend to get a clearer picture of this as testing progresses.
+That depends on the number of bugs discovered in this RC and their severity. As explained in our [release schedule](https://doc.qubes-os.org/en/latest/developer/releases/version-scheme.html#release-schedule-policy) documentation, our usual process after issuing a new RC is to collect bug reports, triage the bugs, and fix them. If warranted, we then issue a new RC that includes the fixes and repeat the process. We continue this iterative procedure until we're left with an RC that's good enough to be declared the stable release. No one can predict, at the outset, how many iterations will be required (and hence how many RCs will be needed before a stable release), but we tend to get a clearer picture of this as testing progresses.
 
 ## How to test Qubes 4.3.0-rc1
 


### PR DESCRIPTION
Avoid redirects on doc links pointing at specific sections, as the
section part doesn't survive redirect - replace them with new
doc.qubes-os.org links directly.

Similar to 378a3e38a9729de21983db16134f6980aeb39e5a commit.

Hopefully it will make CI green again.